### PR TITLE
Script should not fail if an application already exists under '/Applications'

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -34,7 +34,7 @@ append_to_zshrc() {
 cask_install_or_upgrade() {
   if ! cask_is_installed "$1"; then
     fancy_echo "Installing %s ..." "$1"
-    brew cask install --appdir="/Applications" "$@"
+    brew cask install --appdir="/Applications" "$@" --force
   fi
 }
 

--- a/mac.sh
+++ b/mac.sh
@@ -34,7 +34,7 @@ append_to_zshrc() {
 cask_install_or_upgrade() {
   if ! cask_is_installed "$1"; then
     fancy_echo "Installing %s ..." "$1"
-    brew cask install --appdir="/Applications" "$@" --force
+    brew cask install --appdir="/Applications" "$@" || true
   fi
 }
 


### PR DESCRIPTION
Script fails and exits at `brew cask install` if the application already exists in the Applications folder. --force uninstalls the existing application and reinstalls it via cask.