### PR TITLE
Install watchman for jest testing

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -257,6 +257,7 @@ brew_install_or_upgrade 'libyaml'
 brew_install_or_upgrade 'chromedriver'
 brew_install_or_upgrade 'httpie'
 brew_install_or_upgrade 'z'
+brew_install_or_upgrade 'watchman'
 
 # Install applications
 cask_install_or_upgrade 'macvim'


### PR DESCRIPTION
Adds watchman to the laptop script, so that `jest --watch` will work post-`jest v18`.