### PR TITLE
Remove homebrew-versions from the laptop script

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -231,7 +231,6 @@ brew_install_or_upgrade 'ctags'
 brew_install_or_upgrade 'tmux'
 brew_install_or_upgrade 'reattach-to-user-namespace'
 brew_install_or_upgrade 'imagemagick'
-brew_tap 'homebrew/versions'
 brew_install_or_upgrade 'qt55'
 brew link --force qt55
 brew_install_or_upgrade 'fswatch'


### PR DESCRIPTION
As per [here](https://docs.brew.sh/Versions.html), `homebrew-versions` is no longer supported. I think we will be ok if we just remove this line.