### PR TITLE
Remove aptible-cli

### DIFF
--- a/linux.sh
+++ b/linux.sh
@@ -67,7 +67,6 @@ install_ruby() {
   gem update --system
 
   gem_install_or_update 'bundler'
-  gem_install_or_update 'aptible-cli'
 
   fancy_echo "Configuring Bundler ..."
   number_of_cores=$(nproc)

--- a/mac.sh
+++ b/mac.sh
@@ -151,7 +151,6 @@ install_latest_ruby() {
   gem update --system
 
   gem_install_or_update 'bundler'
-  gem_install_or_update 'aptible-cli'
 
   fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
We no longer host on aptible so we no longer need the cli tool.