### PR TITLE
Remove Qt steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ We support:
     _Older OS X versions may work but aren't regularly tested. Bug reports for older
 versions are welcome._
 
-* [XCode version 9.4](https://developer.apple.com/download/more/?name=Xcode) (requires Apple ID login)
-
-    _Latest version of XCode may cause build problems with Qt 5.5 and capybara.  XCode version 9.4 is recommended.  For instructions on downgrading versions see [this article](https://medium.com/@tseboho/how-to-downgrade-xcode-4359df5158d5)._
-
 Base Install
 -------
 
@@ -38,33 +34,6 @@ In order to ensure consistent Docker environment, it should be downloaded manual
 
 [Mac Download](https://www.docker.com/docker-mac)
 [Windows Download](https://www.docker.com/docker-windows)
-
-**For OS X Sierra + (10.12+) and XCode 8:**
-
-With Xcode 8.0, when trying to compile the gem you may get the error Project ERROR: Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild. — even after confirming the license agreement. This is an upstream Qt bug that can be worked around by following these instructions:
-
-1. Find the Qt install folder
-2. Open [Qt_install_folder]/[Qt_version](/clang_64 || )/mkspecs/features/mac/default_pre.prf in a text editor
-
-   If you can't find the file, look for it by searching all files for the following line by running grep -rn /usr/bin/xcrun . in the [Qt_install_folder] or [Qt_version] director
-
-   For this laptop script and Qt 5.5.1, you edit the file directly in VIM via the command line:
-
-   `vim /usr/local/Cellar/qt@5.5/5.5.1/mkspecs/features/mac/default_pre.prf`
-
-3. Find the line with this text (for me it was line 15):
-
-   `isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null"))): \`
-
-4. Replace line with:
-
-   `isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \`
-
-5. Save & re-install the gem
-
-_For further reading: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#macos-sierra-1012_
-
-_Details for manual install of Qt 5.5: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#macos-high-sierra-1013-macos-sierra-1012-el-capitan-1011-and-yosemite-1010_
 
 kutil Install
 --------------
@@ -120,7 +89,6 @@ What it sets up
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
 * [Postgres] for storing relational data
-* [Qt] for headless JavaScript testing via Capybara Webkit
 * [Rbenv] for managing versions of Ruby
 * [Redis] for storing key-value data
 * [Ruby Build] for installing Rubies
@@ -150,7 +118,6 @@ What it sets up
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
 [Postgres]: http://www.postgresql.org/
-[Qt]: http://qt-project.org/
 [Rbenv]: https://github.com/sstephenson/rbenv
 [Redis]: http://redis.io/
 [Ruby Build]: https://github.com/sstephenson/ruby-build

--- a/linux.sh
+++ b/linux.sh
@@ -173,8 +173,6 @@ install_n
 install_yarn
 
 #policygenius project dependencies
-apt_install 'qt5-default'
-apt_install 'libqt5webkit5-dev'
 apt_install 'redis-server'
 install_postgres
 install_elasticsearch

--- a/mac.sh
+++ b/mac.sh
@@ -205,16 +205,6 @@ install_postgresql() {
   fi
 }
 
-install_qt55() {
-  cd  `brew --prefix`/Homebrew/Library/Taps/homebrew/homebrew-core
-  git fetch --unshallow
-  git checkout 9ba3d6ef8891e5c15dbdc9333f857b13711d4e97 Formula/qt@5.5.rb
-  cd -
-
-  brew_install_or_upgrade 'qt@5.5'
-
-  append_to_zshrc 'export PATH="$(brew --prefix qt@5.5)/bin:$PATH"'
-}
 
 ##### Start Installation #####
 
@@ -260,7 +250,6 @@ brew_install_or_upgrade 'z'
 brew_tap 'homebrew/cask'
 cask_install_or_upgrade 'chromedriver'
 install_elasticsearch
-install_qt55
 
 # Install applications
 cask_install_or_upgrade 'google-chrome'


### PR DESCRIPTION
Qt@5.5 is increasingly difficult to install, so we've removed its dependents and this removes it here.

There are a lot of out-of-date things in this script, I didn't try to fix all of them, just remove the Qt-specific parts.