### PR TITLE
Specify bundler version to be compatible with rails 4.2.11

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -151,7 +151,7 @@ install_latest_ruby() {
 
   gem update --system
 
-  gem install 'bundler --version 1.9.9'
+  gem install bundler --version 1.9.9
 
   fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)

--- a/mac.sh
+++ b/mac.sh
@@ -151,7 +151,7 @@ install_latest_ruby() {
 
   gem update --system
 
-  gem_install_or_update 'bundler'
+  gem install 'bundler --version 1.9.9'
 
   fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
The laptop script is currently installing the most up-to-date version of bundler (2.1.4). However, when trying to `bundle install` in the policygenius repo, our version of rails throws an error, requiring bundler to be >= 1.3 and < 2. After trying a few versions, I found downgrading `bundler` to version `1.9.9` resolves the issue. Error screenshot below

<img width="1067" alt="Screen Shot 2020-03-30 at 5 42 30 PM" src="https://user-images.githubusercontent.com/9086184/78076989-84868e00-7375-11ea-87ae-f2aa7d97c6e1.png">

