### PR TITLE
Modify install process for elasticsearch@5.6 on mac

### DIFF
--- a/elasticsearch@5.6.rb
+++ b/elasticsearch@5.6.rb
@@ -1,0 +1,126 @@
+# See comment in `install_elasticsearch` within `mac.sh`. This version of elasticsearch
+# is no longer available in homebrew, and this config file has been copied from the homebrew
+# PR in which it was removed: https://github.com/Homebrew/homebrew-core/pull/57875
+
+class ElasticsearchAT56 < Formula	
+  desc "Distributed search & analytics engine"	
+  homepage "https://www.elastic.co/products/elasticsearch"	
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz"	
+  sha256 "6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f"	
+
+  bottle :unneeded	
+
+  keg_only :versioned_formula	
+
+  deprecate! :date => "2019-03-11"	
+
+  depends_on :java => "1.8"	
+
+  def cluster_name	
+    "elasticsearch_#{ENV["USER"]}"	
+  end	
+
+  def install	
+    # Remove Windows files	
+    rm_f Dir["bin/*.bat"]	
+    rm_f Dir["bin/*.exe"]	
+
+    # Install everything else into package directory	
+    libexec.install "bin", "config", "lib", "modules"	
+
+    # Set up Elasticsearch for local development:	
+    inreplace "#{libexec}/config/elasticsearch.yml" do |s|	
+      # 1. Give the cluster a unique name	
+      s.gsub!(/#\s*cluster\.name: .*/, "cluster.name: #{cluster_name}")	
+
+      # 2. Configure paths	
+      s.sub!(%r{#\s*path\.data: /path/to.+$}, "path.data: #{var}/elasticsearch/")	
+      s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/elasticsearch/")	
+    end	
+
+    inreplace "#{libexec}/bin/elasticsearch.in.sh" do |s|	
+      # Configure ES_HOME	
+      s.sub!(%r{#!/bin/bash\n}, "#!/bin/bash\n\nES_HOME=#{libexec}")	
+    end	
+
+    inreplace "#{libexec}/bin/elasticsearch-plugin" do |s|	
+      # Add the proper ES_CLASSPATH configuration	
+      s.sub!(/SCRIPT="\$0"/, %Q(SCRIPT="$0"\nES_CLASSPATH=#{libexec}/lib))	
+      # Replace paths to use libexec instead of lib	
+      s.gsub!(%r{\$ES_HOME/lib/}, "$ES_CLASSPATH/")	
+    end	
+
+    # Move config files into etc	
+    (etc/"elasticsearch").install Dir[libexec/"config/*"]	
+    (etc/"elasticsearch/scripts").mkdir unless File.exist?(etc/"elasticsearch/scripts")	
+    (libexec/"config").rmtree	
+
+    bin.install libexec/"bin/elasticsearch",	
+                libexec/"bin/elasticsearch-keystore",	
+                libexec/"bin/elasticsearch-plugin",	
+                libexec/"bin/elasticsearch-translog"	
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))	
+  end	
+
+  def post_install	
+    # Make sure runtime directories exist	
+    (var/"elasticsearch/#{cluster_name}").mkpath	
+    (var/"log/elasticsearch").mkpath	
+    ln_s etc/"elasticsearch", libexec/"config" unless (libexec/"config").exist?	
+    (libexec/"plugins").mkpath	
+  end	
+
+  def caveats	
+    <<~EOS
+      Data:    #{var}/elasticsearch/#{cluster_name}/	
+      Logs:    #{var}/log/elasticsearch/#{cluster_name}.log	
+      Plugins: #{libexec}/plugins/	
+      Config:  #{etc}/elasticsearch/	
+      plugin script: #{libexec}/bin/elasticsearch-plugin	
+    EOS
+  end	
+
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/elasticsearch@5.6/bin/elasticsearch"	
+
+  def plist	
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>	
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
+      <plist version="1.0">	
+        <dict>	
+          <key>KeepAlive</key>	
+          <false/>	
+          <key>Label</key>	
+          <string>#{plist_name}</string>	
+          <key>ProgramArguments</key>	
+          <array>	
+            <string>#{opt_bin}/elasticsearch</string>	
+          </array>	
+          <key>EnvironmentVariables</key>	
+          <dict>	
+          </dict>	
+          <key>RunAtLoad</key>	
+          <true/>	
+          <key>WorkingDirectory</key>	
+          <string>#{var}</string>	
+          <key>StandardErrorPath</key>	
+          <string>#{var}/log/elasticsearch.log</string>	
+          <key>StandardOutPath</key>	
+          <string>#{var}/log/elasticsearch.log</string>	
+        </dict>	
+      </plist>	
+    EOS
+  end	
+
+  test do	
+    system "#{libexec}/bin/elasticsearch-plugin", "list"	
+    pid = "#{testpath}/pid"	
+    begin	
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "-Epath.data=#{testpath}/data"	
+      sleep 10	
+      system "curl", "-XGET", "localhost:9200/"	
+    ensure	
+      Process.kill(9, File.read(pid).to_i)	
+    end	
+  end	
+end

--- a/mac.sh
+++ b/mac.sh
@@ -204,6 +204,7 @@ install_elasticsearch() {
   brew tap-new pg-shims/elasticsearch
   cp elasticsearch@5.6.rb /usr/local/Homebrew/Library/Taps/pg-shims/homebrew-elasticsearch/Formula
   brew tap pg-shims/elasticsearch
+  brew install elasticsearch@5.6
   brew services start pg-shims/elasticsearch/elasticsearch@5.6
 }
 

--- a/mac.sh
+++ b/mac.sh
@@ -197,8 +197,14 @@ install_oh_my_zsh() {
 
 install_elasticsearch() {
   cask_install_or_upgrade 'homebrew/cask-versions/adoptopenjdk8'
-  brew_install_or_upgrade 'elasticsearch@5.6'
-  brew services start elasticsearch@5.6
+
+  # Elasticsearch 5.6 was removed from homebrew in this PR: https://github.com/Homebrew/homebrew-core/pull/57875.
+  # In order to install this version, we can point homebrew to a local directory which contains the
+  # elasticsearch@5.6.rb config file copied from that homebrew PR.
+  brew tap-new pg-shims/elasticsearch
+  cp elasticsearch@5.6.rb /usr/local/Homebrew/Library/Taps/pg-shims/homebrew-elasticsearch/Formula
+  brew tap pg-shims/elasticsearch
+  brew services start pg-shims/elasticsearch/elasticsearch@5.6
 }
 
 install_postgresql() {


### PR DESCRIPTION
- Since elasticsearch@5.6 has been removed from homebrew as of [this
pull request](https://github.com/Homebrew/homebrew-core/pull/57875), we
can no longer install that version using homebrew. At least, not without
some modifications. We can instruct homebrew to point to a local dir
which contains homebrew config files, and it will install based on those
files. So, with the `elasticsearch@5.6.rb` file copied from that pull
request above, we can modify the `mac.sh` setup script to still install
elasticsearch@5.6 with no issues.