### PR TITLE
Modify readme to include cloning the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ It is based on [thoughtbot/laptop](https://github.com/thoughtbot/laptop).
 Mac Requirements
 ------------
 
-* Make sure that you've installed XCode *before* running the laptop script. If you've not installed XCode, you will see the following error message: 
+* Make sure that you've installed XCode *before* running the laptop script. If you've not installed XCode, you will see the following error message:
 
 > Can't install the software because it is not currently available from the Software Update server.
 
 Base Install
 -------
 
-Download, review, then execute the script:
+Clone the `laptop` repo, and then execute the script:
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/policygenius/laptop/master/mac.sh
-less mac.sh
+git clone git@github.com:policygenius/laptop.git
+cd laptop
 sh mac.sh 2>&1 | tee ~/laptop.log
 ```
 


### PR DESCRIPTION
- As of the elasticsearch@5.6 change, we use the elasticsearch@5.6.rb
file within this repo. The previous readme instructions did not include
a step to clone the repo; rather, it downloaded only the shell script from
the repo. This means that the elasticsearch step would fail, since there
would be no local `elasticsearch@5.6.rb` file.