### PR TITLE
Update brew list to specify --formula

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -65,7 +65,7 @@ brew_install_or_upgrade() {
 brew_is_installed() {
   local name="$(brew_expand_alias "$1")"
 
-  brew list -1 | grep -Fqx "$name"
+  brew list --formula -1 | grep -Fqx "$name"
 }
 
 brew_is_upgradable() {


### PR DESCRIPTION
Homebrew gently recommended I specify the `--formula` flag when running `brew install` or `brew list` so I obliged.

I see there's `brew_install_or_upgrade` and `cask_install_or_upgrade`. We may want to rename `brew_install_or_upgrade` to `formula_install_or_upgrade` for clarity, curious for others' thoughts there.