### PR TITLE
Update homebrew install command

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -112,8 +112,8 @@ gem_install_or_update() {
 install_or_update_homebrew() {
   if ! command -v brew >/dev/null; then
     fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+      /bin/bash -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
     append_to_zshrc '# recommended by brew doctor'
 

--- a/mac.sh
+++ b/mac.sh
@@ -112,8 +112,8 @@ gem_install_or_update() {
 install_or_update_homebrew() {
   if ! command -v brew >/dev/null; then
     fancy_echo "Installing Homebrew ..."
-      /bin/bash -c \
-        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    /bin/bash -c \
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
     append_to_zshrc '# recommended by brew doctor'
 


### PR DESCRIPTION
The ruby based homebrew install command is deprecated, and I had permissions issues installing on a new Mac as it wanted to be run with sudo. Now it asks for passwords as needed while the script is running.

(See upstream: https://github.com/thoughtbot/laptop/commit/c3d5a26bfa0a506337f937c249ee8bc3a6853cb6)