### PR TITLE
Add kubefwd, remove redpanda

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -203,7 +203,7 @@ brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
 brew_install_or_upgrade 'openssl'
 brew_install_or_upgrade 'elasticsearch@6'
-brew_install_or_upgrade 'redpanda-data/tap/redpanda'
+brew_install_or_upgrade 'txn2/tap/kubefwd'
 brew services start elasticsearch@6
 
 brew unlink openssl && brew link openssl --force


### PR DESCRIPTION
Kubefwd is now used by several of our services and per some PR feedback from [this account-dashboard PR](https://github.com/policygenius/account-dashboard/pull/1587) I'm adding it to the laptop script.

I only added `kubefwd` install for Mac. I don't see Linux install instructions in the repo, [it just links to the releases page](https://github.com/txn2/kubefwd#alternative-installs-targz-rpm-deb)