### PR TITLE
Bump ruby version to 2.7.6

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -129,7 +129,7 @@ install_or_update_homebrew() {
 
 install_ruby() {
   append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
-  ruby_version="2.6.9"
+  ruby_version="2.7.6"
   eval "$(rbenv init - zsh)"
 
   if ! rbenv versions | grep -Fq "$ruby_version"; then
@@ -139,7 +139,7 @@ install_ruby() {
   rbenv global "$ruby_version"
   rbenv shell "$ruby_version"
 
-  gem update --system
+  gem update --system 3.4.22
 }
 
 install_bundler_1_17_3() {


### PR DESCRIPTION
- Bumped Ruby version to 2.7.6
- Specified the latest compatible version (3.4.22) for `rubygems-update`.

Solves two issues:
1) The script had an outdated Ruby version, Policygenius repo currently [uses 2.7.6](https://github.com/policygenius/policygenius/blob/main/.tool-versions).
2) `gem install --system` command failed to run (with either 2.6.9 or 2.7.6) due to attempting to install the latest (incompatible) `rubygems-update` version:

```
ERROR:  Error installing rubygems-update:
	There are no versions of rubygems-update (= 3.5.7) compatible with your Ruby & RubyGems
	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.6.9.207.
```