### PR TITLE
Remove outdated 'brew tap homebrew/cask' command

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -74,11 +74,6 @@ brew_is_upgradable() {
   ! brew outdated --quiet "$name" >/dev/null
 }
 
-brew_tap() {
-  fancy_echo "Tapping %s..." "$1"
-  brew tap "$1" 2> /dev/null
-}
-
 brew_expand_alias() {
   brew info "$1" 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'
 }
@@ -208,7 +203,6 @@ brew services start elasticsearch@6
 
 brew unlink openssl && brew link openssl --force
 
-brew_tap 'homebrew/cask'
 cask_install_or_upgrade 'chromedriver'
 
 # Install applications


### PR DESCRIPTION
- Removes outdated `brew` command to tap 'homebrew/cask' formula. 

## Issue:
Running `brew tap 'homebrew/cask` throws an error:

```
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it done.
```

For context, see [this Stackoverflow discussion](https://stackoverflow.com/a/66081492) on the deprecation of the `brew cask` command in favour of brew commands with --cask.